### PR TITLE
Use requirements file for dev dependencies

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -23,16 +23,13 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
-    - name: Cythonize
-      run: |
-        pip install wheel
-        pip install Cython
-        pip install numpy
-        python setup.py build_ext --inplace
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest
+        pip install -r requirements.txt
+    - name: Cythonize and install package
+      run: |
+        python setup.py build_ext --inplace
         python setup.py install
     - name: Test with pytest
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Cython
+numpy>=1.19
+pytest
+setuptools
+wheel


### PR DESCRIPTION
Closes #11 

With this requirements file, running `pip install -r requirements.txt` should install everything required to build and test the package.
Also updates the CI to use this file for installs. 